### PR TITLE
added mandatory and must support for name, birthDate, identifier and …

### DIFF
--- a/input/fsh/profiles/PatientIndexPatient.fsh
+++ b/input/fsh/profiles/PatientIndexPatient.fsh
@@ -1,6 +1,13 @@
 Profile: UKCoreAccessPatientIndexPatient
-Parent: Patient
+//Parent: Patient
+Parent: UKCore-Patient
 
+Id: UKCoreAccessPatientIndexPatient
+
+Description: "UK Core Access Patient resource profile for patient index lookup, supporting basic data for identification"
+* ^status = #active
+
+// https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient
 /*
 The Patient should be UKCore-Patient
 
@@ -9,3 +16,7 @@ error Structure Definition https://fhir.hl7.org.uk/StructureDefinition/UKCore-Pa
   File: /Users/Dunmail/Documents/Development/UK-Core-Access/input/fsh/profiles/PatientIndexPatient.fsh
   Line: 1 - 2
 */
+* name 1..* MS
+* birthDate 1..1 MS
+* identifier 1..* MS
+


### PR DESCRIPTION
…set profile itself to be active

now derives from UKCore-Patient - this may break the CI build if it cannot access the snapshots in the UK Core package