### PR TITLE
Put full url into the package resource, to try to fix the build. The …

### DIFF
--- a/input/resources/UKCore-Patient.json
+++ b/input/resources/UKCore-Patient.json
@@ -1,7 +1,7 @@
 {
     "resourceType": "StructureDefinition",
     "id": "UKCore-Patient",
-    "url": "UKCore-Patient",
+    "url": "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient",
     "version": "2.2.0",
     "name": "UKCorePatient",
     "title": "UK Core Patient",


### PR DESCRIPTION
…old, incorrect copy, did have a full url.