### PR TITLE
Fix cannonical error

### DIFF
--- a/input/fsh/CapabilityStatement_PatientIndexProvider.fsh
+++ b/input/fsh/CapabilityStatement_PatientIndexProvider.fsh
@@ -11,7 +11,7 @@ Title: "UKCore Access Patient Index Provider"
 * rest.mode = #server
 
 //Patient
-* insert ResourceWithExpectation(#Patient, https://fhir.hl7.org.uk/uk-core-access/StructureDefinition/UKCoreAccessPatientIndexPatient, #SHALL)
+* insert ResourceWithExpectation(#Patient, https://fhir.hl7.org.uk/StructureDefinition/UKCoreAccessPatientIndexPatient, #SHALL)
 * insert InteractionWithExpectation(#search-type, #SHALL)
 * insert SearchParamWithExpectation(_id, #token, #SHOULD)
 * insert SearchParamWithExpectation(birthdate, #date, #SHOULD)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: uk-core-access
-canonical: https://fhir.hl7.org.uk/uk-core-access
+canonical: https://fhir.hl7.org.uk
 name: UKCoreAccess
 title: HL7 UK - UK Core Access
 # description: Example Implementation Guide for getting started with SUSHI


### PR DESCRIPTION
Hi, this fixes the canonical error (below) for the UK Core resource in the build.  It was mentioned to me that the lack of snapshots in the UK Core profiles was thought to be causing this error, but it appears to be just a canonical mismatch.  Adding snapshots wouldn't have resolved this error, unless there is another one?    I just ran a build of what is currently in master.

![image](https://github.com/HL7-UK/UK-Core-Access/assets/93662162/dfb39c01-39ff-4754-a9f6-6c1edad4fe60)

To fix this at a package level you'd need to add `uk-core-access` into the canonicals of the profiles.